### PR TITLE
INFRA-297: Create uh_core module/function responsible for HTML tags stripping

### DIFF
--- a/cronman/monitor.py
+++ b/cronman/monitor.py
@@ -9,11 +9,11 @@ import logging
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.functional import cached_property
-from django.utils.html import strip_tags
 from django.utils.http import urlencode
-from django.utils.six.moves import html_parser as HTMLParser
 
 import requests
+
+from uh_core.htmltools import strip_tags
 
 from cronman.config import app_settings
 from cronman.exceptions import MissingDependency
@@ -149,8 +149,6 @@ class Slack(object):
 
     def _prepare_message(self, message):
         # slack don't process html entities
-        html_parser = HTMLParser.HTMLParser()
-        message = html_parser.unescape(message)
         # slack also don't render html itself
         message = strip_tags(message)
         return message


### PR DESCRIPTION
JIRA: https://motocommerce.atlassian.net/browse/INFRA-297

Related PR: https://github.com/unhaggle/uh_core/pull/102

As part of the INFRA-297 ticket, this PR will update instances of HTML tag stripping (i.e. `strip_tags`) to use the new `strip_tags` utility function defined in `uh_core`.