### PR TITLE
INFRA-755: Making Python3 official for paymentinsights.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,9 @@ cache:
 python:
   - "2.7"
   - "3.6"
+  - "3.7"
 install:
-  - pip install -U pip==19.0.3
+  - pip install -U pip setuptools
   - pip install -e .
   - pip install coverage
 script:


### PR DESCRIPTION
During the execution of paymentinsights with Python3 we have the following error:

```
File "/root/.pyenv/versions/3.6.9/lib/python3.6/logging/__init__.py", line 388, in usesTime
  return self._fmt.find(self.asctime_search) >= 0
TypeError: a bytes-like object is required, not 'str'
```

# Steps to reproduce

```
cd paymentinsights/docker
docker-compose build
docker-compose run paymentinsights configure
DJANGO_CONFIGURATION=StagingPIApp docker-compose run paymentinsights /bin/bash -c "mkdir /application/logs; python manage.py cron_remote_manager disable ALL --wait"

```

