### PR TITLE
Support custom order of CronTasks execution

### DIFF
--- a/cronman/config.py
+++ b/cronman/config.py
@@ -111,5 +111,9 @@ class AppSettings(object):
         "cronman.redis_client.get_strict_redis_default",
     )  # type: Text
 
+    CRONMAN_CRON_TASKS_EXECUTION_ORDER = Setting(
+        "CRONMAN_CRON_TASKS_EXECUTION_ORDER", ""
+    )  # type: Text
+
 
 app_settings = AppSettings()

--- a/cronman/taxonomies.py
+++ b/cronman/taxonomies.py
@@ -85,3 +85,9 @@ class CronSchedulerStatus(object):
 
     DISABLED = "disabled"
     ENABLED = "enabled"
+
+
+class CronTaskExecutionOrder(object):
+    FIFO = "start_at"
+    LIFO = "-start_at"
+


### PR DESCRIPTION
This PR adds **`CRONMAN_CRON_TASKS_EXECUTION_ORDER`** to customize
the cron tasks execution order.

**`CRONMAN_CRON_TASKS_EXECUTION_ORDER`** gets any column name from the
CronTask table and is passed to the `order_by` queryset method.

**`CronTaskExecutionOrder`** defines two ordering, LIFO and FIFO where
both are ordered by `CronTask.start_at`. By default, FIFO is
applied.
