### PR TITLE
INFRA-966: Replace deprecated 'raven' library with 'sentry_sdk'.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
   - "2.7"
   - "3.6"
 install:
-  - pip install -U pip==19.0.3
+  - pip install -U pip setuptools
   - pip install -e .
   - pip install coverage
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM uhinfra/centos7-python3.7:v13
-MAINTAINER Motoinsight Infra-Team <infra@motoinsight.com>
 
-ADD . /application/cronman
+COPY . /application/cronman
 RUN pip install -e /application/cronman
 # NOTE: django>=2.2 requires sqlite 3.8.3 and centos7 have only 3.7.X
-RUN pip install pytest pytest-django sentry_sdk raven redis mock sql "django<2.2"
+RUN pip install pytest pytest-django sentry_sdk raven redis mock sql "django==2.1.15"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM uhinfra/centos7-python3.7:v13
+MAINTAINER Motoinsight Infra-Team <infra@motoinsight.com>
+
+ADD . /application/cronman
+RUN pip install -e /application/cronman
+# NOTE: django>=2.2 requires sqlite 3.8.3 and centos7 have only 3.7.X
+RUN pip install pytest pytest-django sentry_sdk raven redis mock sql "django<2.2"

--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ Cron job `RunCronTasks` started every 4 minutes by the scheduler will spawn a se
 
 ## Changelog
 
+2020-04-23 - 2.0.0 Replace raven with sentry-sdk.
 2020-01-09 - 1.2.0 Django 2 compatibility.
 2019-04-30 - 1.1.1 Pre-commit.com hooks support. Docs update
 2019-03-13 - 1.1.0 Add support for cronitor ping for cron_scheduler

--- a/cronman/monitor.py
+++ b/cronman/monitor.py
@@ -33,7 +33,8 @@ def _get_sentry_sdk():
         ).integrations.django.DjangoIntegration
     except ImportError:
         raise MissingDependency(
-            "Unable to import sentry_sdk. Sentry monitor requires this dependency."
+            "Unable to import sentry_sdk. "
+            "Sentry monitor requires this dependency."
         )
 
     for setting in (

--- a/cronman/tests/settings.py
+++ b/cronman/tests/settings.py
@@ -25,7 +25,7 @@ INSTALLED_APPS = (
 MIDDLEWARE = (
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
-    "django.contrib.sessions.middleware.SessionMiddleware"
+    "django.contrib.sessions.middleware.SessionMiddleware",
 )
 
 TEMPLATES = [

--- a/cronman/version.py
+++ b/cronman/version.py
@@ -3,4 +3,4 @@
 
 from __future__ import unicode_literals
 
-__version__ = "2.2.0"
+__version__ = "2.0.0"

--- a/cronman/version.py
+++ b/cronman/version.py
@@ -3,4 +3,4 @@
 
 from __future__ import unicode_literals
 
-__version__ = "1.2.0"
+__version__ = "2.2.0"

--- a/cronman/worker/worker.py
+++ b/cronman/worker/worker.py
@@ -269,7 +269,7 @@ class CronWorker(BaseCronObject):
         cronitor_id = self.cronitor_id or cron_job_class.cronitor_id
         message = format_exception(error)
         self.logger.error(message)
-        self.sentry.capture_exception()
+        self.sentry.capture_exception(error)
         if cronitor_id and cron_job_class.cronitor_ping_fail:
             self.cronitor.fail(cronitor_id, msg=message)
         if self.debug:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.7"
+services:
+  cronman:
+    container_name: cronman
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: cronman:v1
+    volumes:
+      - ${UNHAGGLE_ROOT}/django-cronman:/application/cronman

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,4 +7,4 @@ services:
       dockerfile: Dockerfile
     image: cronman:v1
     volumes:
-      - ${UNHAGGLE_ROOT}/django-cronman:/application/cronman
+      - ${CRONMAN_REPO}/application/cronman

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+addopts = --tb=short
+norecursedirs = .git _build tmp*
+DJANGO_SETTINGS_MODULE=cronman.tests.settings
+django_find_project = true

--- a/setup.py
+++ b/setup.py
@@ -140,8 +140,8 @@ setup(
         "typing",
     ],
     include_package_data=True,
-    tests_require=["mock", "raven < 5.33", "redis < 2.11"],
-    extras_require={"redis": ["redis < 2.11"], "sentry": ["raven < 5.33"]},
+    tests_require=["mock", "sentry_sdk", "redis < 2.11"],
+    extras_require={"redis": ["redis < 2.11"], "sentry": ["sentry_sdk"]},
     cmdclass={
         "test": TestCommand,
         "shell": ShellCommand,
@@ -149,6 +149,7 @@ setup(
         "migrate": MigrateCommand,
     },
     classifiers=[
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 2.7",
         "License :: OSI Approved :: BSD License",

--- a/setup.py
+++ b/setup.py
@@ -137,6 +137,7 @@ setup(
         "django < 3.0",
         "python-dateutil",
         "requests",
+        "six",
         "typing",
     ],
     include_package_data=True,


### PR DESCRIPTION
## Description

Replace the deprecated `raven` library with the new version `sentry_sdk`.
