### PR TITLE
INFRA-1877: Replace baseimage with bullseye.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
-FROM uhinfra/centos7-python:v19-3.6-psql10
+FROM uhinfra/bullseye:v2.0.3-py3.6-psql10-node12
 
 COPY . /application/cronman
-RUN source $HOME/.bashrc  && \
+RUN . $HOME/.bashrc  && \
     pip install -Ur /application/cronman/requirements.txt  && \
     pip install --no-deps -e /application/cronman
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,6 +5,5 @@ set -e
 # Configure environment
 
 source /etc/profile.d/venv.sh
-source /etc/profile.d/psql.sh
 
 exec $@


### PR DESCRIPTION
## JIRA

https://motocommerce.atlassian.net/browse/INFRA-1877

## Description

Change the baseimage OS from centos7 to Debian 11 (bullseye).

## See also

* [django-cronman pr41](https://github.com/unhaggle/django-cronman/pull/41)
* [tierless pr419](https://github.com/unhaggle/tierless/pull/419)
* [uh_inventory pr465](https://github.com/unhaggle/uh_inventory/pull/465)
* [api_clients pr91](https://github.com/unhaggle/api_clients/pull/91)
* [uh_status pr17](https://github.com/unhaggle/uh_status/pull/17)
* [moto_core pr126](https://github.com/unhaggle/moto_core/pull/126)
* [uh_core pr260](https://github.com/unhaggle/uh_core/pull/260)
