### PR TITLE
MI-2504: Use new Slack API

### DIFF
--- a/cronman/monitor.py
+++ b/cronman/monitor.py
@@ -156,15 +156,10 @@ class Slack(object):
                 "Slack integration. Please provide values for these settings "
                 "or disable Slack integration (CRONMAN_SLACK_ENABLED = False)."
             )
-        channel_url = "{}?{}".format(
-            self.url,
-            urlencode(
-                (
-                    ("token", self.token),
-                    ("channel", "#{}".format(channel or self.default_channel)),
-                )
-            ),
-        )
+        headers = {
+            'Content-type': 'application/json; charset=utf-8',
+            'Authentication': f'Bearer {self.token}'
+        }
         # prepare message
         message = self._prepare_message(message)
 
@@ -179,8 +174,12 @@ class Slack(object):
                 # you don't get to choose. All data should be encoded
                 # manually by the user before it's passed to requests.
                 encoded_chunk = chunk.encode("utf-8")
+                data = {
+                    'text': encoded_chunk,
+                    'channel': channel or self.default_channel
+                }
                 response = requests.post(
-                    channel_url, data=encoded_chunk, timeout=7
+                    self.url, json=data, timeout=7, headers=headers
                 )
                 response.raise_for_status()
         except Exception as error:

--- a/cronman/monitor.py
+++ b/cronman/monitor.py
@@ -158,7 +158,7 @@ class Slack(object):
             )
         headers = {
             'Content-type': 'application/json;charset=utf-8',
-            'Authentication': f'Bearer {self.token}'
+            'Authorization': f'Bearer {self.token}'
         }
         # prepare message
         message = self._prepare_message(message)

--- a/cronman/monitor.py
+++ b/cronman/monitor.py
@@ -157,7 +157,7 @@ class Slack(object):
                 "or disable Slack integration (CRONMAN_SLACK_ENABLED = False)."
             )
         headers = {
-            'Content-type': 'application/json; charset=utf-8',
+            'Content-type': 'application/json;charset=utf-8',
             'Authentication': f'Bearer {self.token}'
         }
         # prepare message

--- a/cronman/tests/test_monitor.py
+++ b/cronman/tests/test_monitor.py
@@ -219,7 +219,7 @@ class SlackTestCase(BaseCronTestCase):
         slack.post("This is a test!")
         mock_post.assert_called_once_with(
             "https://fake-chat.slack.com/services/hooks/slackbot",
-            json={"text": "This is a test!", "channel":"cronitor"},
+            json={"text": b"This is a test!", "channel":"cronitor"},
             timeout=7,
             headers={'Content-type': 'application/json;charset=utf-8', 'Authentication': "Bearer sLaCkTokEn"}
         )
@@ -238,7 +238,7 @@ class SlackTestCase(BaseCronTestCase):
         slack.post("This is a test!", channel="dev")
         mock_post.assert_called_once_with(
             "https://fake-chat.slack.com/services/hooks/slackbot",
-            json={"text": "This is a test!", "channel":"dev"},
+            json={"text": b"This is a test!", "channel":"dev"},
             timeout=7,
             headers={'Content-type': 'application/json;charset=utf-8', 'Authentication': "Bearer sLaCkTokEn"}
         )
@@ -260,7 +260,7 @@ class SlackTestCase(BaseCronTestCase):
         slack.post("This is a test!")
         mock_post.assert_called_once_with(
             "https://fake-chat.slack.com/services/hooks/slackbot",
-            json={"text": "This is a test!", "channel":"cronitor"},
+            json={"text": b"This is a test!", "channel":"cronitor"},
             timeout=7,
             headers={'Content-type': 'application/json;charset=utf-8', 'Authentication': "Bearer sLaCkTokEn"}
         )

--- a/cronman/tests/test_monitor.py
+++ b/cronman/tests/test_monitor.py
@@ -218,10 +218,10 @@ class SlackTestCase(BaseCronTestCase):
         slack.logger = mock.MagicMock()
         slack.post("This is a test!")
         mock_post.assert_called_once_with(
-            "https://fake-chat.slack.com/services/hooks/slackbot?"
-            "token=sLaCkTokEn&channel=%23cronitor",
-            data=force_bytes("This is a test!"),
+            "https://fake-chat.slack.com/services/hooks/slackbot",
+            json={"text": "This is a test!", "channel":"cronitor"},
             timeout=7,
+            headers={'Content-type': 'application/json;charset=utf-8', 'Authentication': "Bearer sLaCkTokEn"}
         )
 
     @override_cron_settings(
@@ -237,10 +237,10 @@ class SlackTestCase(BaseCronTestCase):
         slack.logger = mock.MagicMock()
         slack.post("This is a test!", channel="dev")
         mock_post.assert_called_once_with(
-            "https://fake-chat.slack.com/services/hooks/slackbot?"
-            "token=sLaCkTokEn&channel=%23dev",
-            data=force_bytes("This is a test!"),
+            "https://fake-chat.slack.com/services/hooks/slackbot",
+            json={"text": "This is a test!", "channel":"dev"},
             timeout=7,
+            headers={'Content-type': 'application/json;charset=utf-8', 'Authentication': "Bearer sLaCkTokEn"}
         )
 
     @override_cron_settings(
@@ -259,10 +259,10 @@ class SlackTestCase(BaseCronTestCase):
         slack.logger = mock.MagicMock()
         slack.post("This is a test!")
         mock_post.assert_called_once_with(
-            "https://fake-chat.slack.com/services/hooks/slackbot?"
-            "token=sLaCkTokEn&channel=%23cronitor",
-            data=force_bytes("This is a test!"),
+            "https://fake-chat.slack.com/services/hooks/slackbot",
+            json={"text": "This is a test!", "channel":"cronitor"},
             timeout=7,
+            headers={'Content-type': 'application/json;charset=utf-8', 'Authentication': "Bearer sLaCkTokEn"}
         )
         slack.logger.error.assert_has_calls(
             [mock.call("Slack request failed: ConnectTimeout: msg")]

--- a/cronman/tests/test_monitor.py
+++ b/cronman/tests/test_monitor.py
@@ -221,7 +221,7 @@ class SlackTestCase(BaseCronTestCase):
             "https://fake-chat.slack.com/services/hooks/slackbot",
             json={"text": b"This is a test!", "channel":"cronitor"},
             timeout=7,
-            headers={'Content-type': 'application/json;charset=utf-8', 'Authentication': "Bearer sLaCkTokEn"}
+            headers={'Content-type': 'application/json;charset=utf-8', 'Authorization': "Bearer sLaCkTokEn"}
         )
 
     @override_cron_settings(
@@ -240,7 +240,7 @@ class SlackTestCase(BaseCronTestCase):
             "https://fake-chat.slack.com/services/hooks/slackbot",
             json={"text": b"This is a test!", "channel":"dev"},
             timeout=7,
-            headers={'Content-type': 'application/json;charset=utf-8', 'Authentication': "Bearer sLaCkTokEn"}
+            headers={'Content-type': 'application/json;charset=utf-8', 'Authorization': "Bearer sLaCkTokEn"}
         )
 
     @override_cron_settings(
@@ -262,7 +262,7 @@ class SlackTestCase(BaseCronTestCase):
             "https://fake-chat.slack.com/services/hooks/slackbot",
             json={"text": b"This is a test!", "channel":"cronitor"},
             timeout=7,
-            headers={'Content-type': 'application/json;charset=utf-8', 'Authentication': "Bearer sLaCkTokEn"}
+            headers={'Content-type': 'application/json;charset=utf-8', 'Authorization': "Bearer sLaCkTokEn"}
         )
         slack.logger.error.assert_has_calls(
             [mock.call("Slack request failed: ConnectTimeout: msg")]

--- a/cronman/version.py
+++ b/cronman/version.py
@@ -3,4 +3,4 @@
 
 from __future__ import unicode_literals
 
-__version__ = "3.2.0b43dev0"
+__version__ = "3.2.0"

--- a/cronman/version.py
+++ b/cronman/version.py
@@ -3,4 +3,4 @@
 
 from __future__ import unicode_literals
 
-__version__ = "3.1.2"
+__version__ = "3.2.0"

--- a/cronman/version.py
+++ b/cronman/version.py
@@ -3,4 +3,4 @@
 
 from __future__ import unicode_literals
 
-__version__ = "3.2.0"
+__version__ = "3.2.0b43dev0"

--- a/cronman/version.py
+++ b/cronman/version.py
@@ -3,4 +3,4 @@
 
 from __future__ import unicode_literals
 
-__version__ = "3.1.1"
+__version__ = "3.1.2"


### PR DESCRIPTION
## PR Description

The purpose of this PR is to update the slack integration. Currently it uses an old URL format `https://*.slack.com/services/hooks/slackbot` to `POST` messages. This had been deprecated and not working anymore. So we need to update the URL and the authentication method:

- Use the new URL `https://slack.com/api/chat.postMessage` to `POST` message requests
- Send the authorization `token` value in header instead of in the URL.
- Change the `payload` format for the new URL.


## Post Deployment Changes.
- After the deployment, we need to change the value for `CRONMAN_SLACK_URL` to `https://slack.com/api/chat.postMessage`.
- Generate a new token for this URL if needed, and set its value in `CRONMAN_SLACK_TOKEN`